### PR TITLE
fix: update GitHub Actions workflow to trigger on push to master branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
This pull request updates the deployment workflow for documentation by changing the branch that triggers the workflow from `main` to `master`. This ensures that documentation is deployed when changes are pushed to the `master` branch instead of `main`.