### PR TITLE
Release 1.2.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@ node_modules/
 .idea/
 .vscode/
 docs/.vitepress/cache
+docs/.vitepress/dist
 assets/
 package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@linezed/terminal",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@linezed/terminal",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^24.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linezed/terminal",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "A feature-rich CLI framework for Node.js",
     "keywords": [
         "framework",

--- a/src/cli/impl/argv/argv.ts
+++ b/src/cli/impl/argv/argv.ts
@@ -178,6 +178,7 @@ export default class IArgv implements Argv {
                 }
 
                 this.Error.code = e.code;
+                this.Error.message = e.message;
                 return;
             }
 
@@ -187,6 +188,7 @@ export default class IArgv implements Argv {
             }
 
             this.Error.code = ArgvErrorCode.TypeMismatch;
+            this.Error.message = (e as Error).message;
         }
 
         // Fire the handler

--- a/src/cli/impl/help/help.ts
+++ b/src/cli/impl/help/help.ts
@@ -48,7 +48,10 @@ export default function GenerateHelp(
     if (argv && argv.Error) {
         resp += Formatter.FormatWithProps(
             config.format.error.format,
-            app,
+            {
+                ...app,
+                Error: argv.Error
+            },
             ...config.format.error.args
         );
 


### PR DESCRIPTION
This pull request includes a minor version bump and several improvements related to error handling and documentation build artifacts. The main changes focus on enhancing error reporting in the CLI framework and updating the project configuration to ignore generated documentation files.

**Error handling improvements:**

* In `src/cli/impl/argv/argv.ts`, the error object's `message` property is now set alongside the `code` property when handling errors, ensuring more informative error reporting. [[1]](diffhunk://#diff-cea4f49025b1afaf1ed49f08db2cbffecd6ddd76bda44a83e144a560e1c2fc39R181) [[2]](diffhunk://#diff-cea4f49025b1afaf1ed49f08db2cbffecd6ddd76bda44a83e144a560e1c2fc39R191)
* In `src/cli/impl/help/help.ts`, the help generation now passes the full error object (including the message) to the formatter, allowing error messages to be displayed in the help output.

**Project configuration and versioning:**

* In `.npmignore`, the `docs/.vitepress/dist` directory is now ignored, preventing built documentation files from being published to npm.
* The package version in `package.json` is updated from `1.2.0` to `1.2.1` to reflect these changes.