### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@linezed/terminal",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@linezed/terminal",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^24.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@linezed/terminal",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "A feature-rich CLI framework for Node.js",
     "keywords": [
         "framework",


### PR DESCRIPTION
This pull request makes a minor update to the package version in `package.json`. The version is incremented from `1.2.1` to `1.2.2`, indicating a small change or patch release.